### PR TITLE
Added Expectile Regression Naive implementation

### DIFF
--- a/rlax/__init__.py
+++ b/rlax/__init__.py
@@ -101,6 +101,7 @@ from rlax._src.value_learning import categorical_q_learning
 from rlax._src.value_learning import categorical_td_learning
 from rlax._src.value_learning import double_q_learning
 from rlax._src.value_learning import expected_sarsa
+from rlax._src.value_learning import expectile_naive_q_learning
 from rlax._src.value_learning import persistent_q_learning
 from rlax._src.value_learning import q_lambda
 from rlax._src.value_learning import q_learning
@@ -143,6 +144,7 @@ __all__ = (
     "epsilon_greedy",
     "epsilon_softmax",
     "expected_sarsa",
+    "expectile_naive_q_learning",
     "feature_control_rewards",
     "gaussian_diagonal",
     "HYPERBOLIC_SIN_PAIR",


### PR DESCRIPTION
Continuing from https://github.com/deepmind/rlax/issues/9, I made the minor changes Mark and Will recommended, but did not pursue writing `expectile_naive_regression_loss()` to work with expectile regression since properly implemented expectile regression is more complicated (and I think will require its own PR).