### PR TITLE
Update simple_dqn.py - rlax.examples import

### DIFF
--- a/examples/simple_dqn.py
+++ b/examples/simple_dqn.py
@@ -25,7 +25,7 @@ import jax
 import jax.numpy as jnp
 import optax
 import rlax
-from rlax.examples import experiment
+import experiment
 
 Params = collections.namedtuple("Params", "online target")
 ActorState = collections.namedtuple("ActorState", "count")


### PR DESCRIPTION
import rlax.examples does not work:

```
Traceback (most recent call last):
  File "examples/simple_dqn.py", line 28, in <module>
    from rlax.examples import experiment
ModuleNotFoundError: No module named 'rlax.examples'
```