### PR TITLE
Fix/dqn example

### DIFF
--- a/examples/experiment.py
+++ b/examples/experiment.py
@@ -28,19 +28,21 @@ def run_loop(
   params = agent.initial_params(next(rng))
   learner_state = agent.initial_learner_state(params)
 
+  train_actor_state = agent.initial_actor_state()
+
   print(f"Training agent for {train_episodes} episodes")
   for episode in range(train_episodes):
 
     # Prepare agent, environment and accumulator for a new episode.
     timestep = environment.reset()
     accumulator.push(timestep, None)
-    actor_state = agent.initial_actor_state()
+    
 
     while not timestep.last():
 
       # Acting.
-      actor_output, actor_state = agent.actor_step(
-          params, timestep, actor_state, next(rng), evaluation=False)
+      actor_output, train_actor_state = agent.actor_step(
+          params, timestep, train_actor_state, next(rng), evaluation=False)
 
       # Agent-environment interaction.
       action = int(actor_output.actions)
@@ -57,13 +59,13 @@ def run_loop(
     # Evaluation.
     if not episode % evaluate_every:
       returns = 0.
+      eval_actor_state = agent.initial_actor_state()
       for _ in range(eval_episodes):
         timestep = environment.reset()
-        actor_state = agent.initial_actor_state()
 
         while not timestep.last():
-          actor_output, actor_state = agent.actor_step(
-              params, timestep, actor_state, next(rng), evaluation=True)
+          actor_output, eval_actor_state = agent.actor_step(
+              params, timestep, eval_actor_state, next(rng), evaluation=True)
           timestep = environment.step(int(actor_output.actions))
           returns += timestep.reward
 

--- a/examples/simple_dqn.py
+++ b/examples/simple_dqn.py
@@ -19,6 +19,7 @@ import random
 from absl import app
 from absl import flags
 from bsuite.environments import catch
+from examples import experiment
 import haiku as hk
 from haiku import nets
 import jax
@@ -26,7 +27,6 @@ import jax.numpy as jnp
 import numpy as np
 import optax
 import rlax
-from rlax.examples import experiment
 
 Params = collections.namedtuple("Params", "online target")
 ActorState = collections.namedtuple("ActorState", "count")


### PR DESCRIPTION
This PR includes two fixes for the dqn example:
1. Fix import error:
    ```
    Traceback (most recent call last):
      File "examples/simple_dqn.py", line 28, in <module>
        from rlax.examples import experiment
    ModuleNotFoundError: No module named 'rlax.examples'
    ``` 
    There is already a [PR](https://github.com/deepmind/rlax/pull/12) for this, but this fixes the whole dqn example. 

2. Fix epsilon scheduling (https://github.com/deepmind/rlax/issues/102). 

      These lines ([1](https://github.com/deepmind/rlax/blob/819b9d0f33ea2cb61330925fff981411e902412e/examples/experiment.py#L37) , [2](https://github.com/deepmind/rlax/blob/819b9d0f33ea2cb61330925fff981411e902412e/examples/experiment.py#L62)) reset the actor steps, which results in the wrong counts being passed to the eps scheduling function [here](https://github.com/deepmind/rlax/blob/819b9d0f33ea2cb61330925fff981411e902412e/examples/simple_dqn.py#L129). This outcome of this is a cyclic eps schedule which is not intended. 