### PR TITLE
Parallelize lambda returns with associative scan

### DIFF
--- a/rlax/_src/multistep.py
+++ b/rlax/_src/multistep.py
@@ -104,15 +104,24 @@ def lambda_returns(
   # If scalar make into vector.
   lambda_ = jnp.ones_like(discount_t) * lambda_
 
-  # Work backwards to compute `G_{T-1}`, ..., `G_0`.
-  def _body(acc, xs):
-    returns, discounts, values, lambda_ = xs
-    acc = returns + discounts * ((1-lambda_) * values + lambda_ * acc)
-    return acc, acc
+  # Express each update as the affine map `x -> shift + scale * x`, then
+  # compose suffixes in parallel to compute `G_{T-1}`, ..., `G_0`.
+  scales = discount_t * lambda_
+  shifts = r_t + discount_t * (1. - lambda_) * v_t
 
-  _, returns = jax.lax.scan(
-      # pyrefly: ignore[bad-index]
-      _body, v_t[-1], (r_t, discount_t, v_t, lambda_), reverse=True)
+  # Fold the terminal bootstrap into the last map so the scan outputs returns.
+  # pyrefly: ignore[bad-index]
+  shifts = shifts.at[-1].add(scales[-1] * v_t[-1])
+  scales = scales.at[-1].set(0.)
+
+  def _compose(later, earlier):
+    later_scale, later_shift = later
+    earlier_scale, earlier_shift = earlier
+    return (earlier_scale * later_scale,
+            earlier_shift + earlier_scale * later_shift)
+
+  _, returns = jax.lax.associative_scan(
+      _compose, (scales, shifts), reverse=True)
 
   return jax.lax.select(stop_target_gradients,
                         jax.lax.stop_gradient(returns),

--- a/rlax/_src/multistep_test.py
+++ b/rlax/_src/multistep_test.py
@@ -52,6 +52,76 @@ class LambdaReturnsTest(parameterized.TestCase):
     # Test return estimate.
     np.testing.assert_allclose(self.expected, actual, rtol=1e-5)
 
+  @staticmethod
+  def _sequential_reference(r_t, discount_t, v_t, lambda_):
+    lambda_ = jnp.ones_like(discount_t) * lambda_
+
+    def _body(acc, xs):
+      reward, discount, value, lambda_ = xs
+      acc = reward + discount * ((1. - lambda_) * value + lambda_ * acc)
+      return acc, acc
+
+    return jax.lax.scan(
+        _body, v_t[-1], (r_t, discount_t, v_t, lambda_), reverse=True)[1]
+
+  @chex.all_variants()
+  @parameterized.named_parameters(
+      ('length_one_scalar_lambda', 1, False),
+      ('non_power_of_two_vector_lambda', 17, True),
+      ('long_vector_lambda', 4097, True),
+  )
+  def test_matches_sequential_reference(self, sequence_length, vector_lambda):
+    keys = jax.random.split(jax.random.key(sequence_length), 4)
+    r_t = jax.random.normal(keys[0], (sequence_length,))
+    discount_t = 0.99 * jax.random.uniform(keys[1], (sequence_length,))
+    discount_t = discount_t.at[::max(1, sequence_length // 4)].set(0.)
+    v_t = jax.random.normal(keys[2], (sequence_length,))
+    if vector_lambda:
+      lambda_ = jax.random.uniform(keys[3], (sequence_length,))
+    else:
+      lambda_ = 0.75
+
+    expected = self._sequential_reference(r_t, discount_t, v_t, lambda_)
+    actual = self.variant(multistep.lambda_returns)(
+        r_t, discount_t, v_t, lambda_)
+
+    np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-6)
+
+  def test_gradients_match_sequential_reference(self):
+    keys = jax.random.split(jax.random.key(7), 4)
+    inputs = (
+        jax.random.normal(keys[0], (17,)),
+        0.99 * jax.random.uniform(keys[1], (17,)),
+        jax.random.normal(keys[2], (17,)),
+        jax.random.uniform(keys[3], (17,)),
+    )
+
+    def summed_returns(fn, *args):
+      return jnp.sum(fn(*args))
+
+    expected = jax.grad(
+        functools.partial(summed_returns, self._sequential_reference),
+        argnums=(0, 1, 2, 3))(*inputs)
+    actual = jax.grad(
+        functools.partial(summed_returns, multistep.lambda_returns),
+        argnums=(0, 1, 2, 3))(*inputs)
+
+    chex.assert_trees_all_close(expected, actual, rtol=1e-5, atol=1e-6)
+
+  def test_stop_target_gradients(self):
+    r_t = jnp.array([1., 2., 3.])
+    discount_t = jnp.array([0.9, 0.9, 0.9])
+    v_t = jnp.array([0.5, 1., 1.5])
+    lambda_ = jnp.array([0.7, 0.8, 0.9])
+
+    gradients = jax.grad(
+        lambda *args: jnp.sum(multistep.lambda_returns(
+            *args, stop_target_gradients=True)),
+        argnums=(0, 1, 2, 3))(r_t, discount_t, v_t, lambda_)
+
+    chex.assert_trees_all_close(
+        gradients, jax.tree.map(jnp.zeros_like, gradients))
+
 
 class DiscountedReturnsTest(parameterized.TestCase):
 


### PR DESCRIPTION
## Summary

The lambda return implementation with scan can be improved for long horizons by using associative scan instead. 

This PR replaces the sequential `jax.lax.scan` in `lambda_returns` with a reverse `jax.lax.associative_scan` over affine maps.

The recurrence

\[
G_t = r_t + \gamma_t \left[(1 - \lambda_t) v_t + \lambda_t G_{t+1}\right]
\]

is represented as `shift + scale * G`, allowing suffixes to be composed in parallel. The terminal bootstrap is folded into the final map.

The public API, input validation, output shapes, scalar/vector lambda handling, and `stop_target_gradients` behavior are unchanged (see tests below).

## Motivation

`lax.scan` has linear dependency depth and serializes work across the trajectory. This is efficient on CPU but becomes expensive on GPU, particularly for long horizons.

`associative_scan` increases compilation cost and performs more total work, but reduces the recurrence to logarithmic parallel depth.

## GPU benchmarks

Measured with JAX 0.8.0 under `jax.jit(jax.vmap(...))` on the Voyager Fly cluster. Runtime is the median of synchronized executions after 10 warm-up iterations.

| GPU | Shape `(batch, time)` | Sequential compile / run | Associative compile / run | Runtime speedup |
|---|---:|---:|---:|---:|
| RTX PRO 6000 | `(1024, 16)` | 79 ms / 145 µs | 132 ms / 32 µs | 4.52× |
| RTX PRO 6000 | `(16, 64)` | 77 ms / 448 µs | 343 ms / 35 µs | 12.92× |
| RTX PRO 6000 | `(16, 16384)` | 116 ms / 104.9 ms | 756 ms / 109 µs | 965.6× |
| GB200 | `(1024, 16)` | 100 ms / 259 µs | 172 ms / 137 µs | 1.89× |
| GB200 | `(16, 64)` | 99 ms / 614 µs | 458 ms / 159 µs | 3.87× |
| GB200 | `(16, 16384)` | 139 ms / 130.4 ms | 1,106 ms / 171 µs | 762.1× |

The maximum absolute difference from the sequential implementation was `1.19e-6`.

## CPU trade-off

Associative scan is slower on CPU, as expected from its additional work:

| Shape `(batch, time)` | Sequential runtime | Associative runtime |
|---|---:|---:|
| `(16, 64)` | 5.2 µs | 14.9 µs |
| `(16, 1024)` | 24.5 µs | 65.7 µs |
| `(16, 16384)` | 246.2 µs | 487.3 µs |

These measurements used JAX 0.11.0 on an Apple Silicon CPU. 
One possible mitigation would be to automatically or explicitly branch the implementation.

## Tests

Regression coverage compares the implementation with the previous sequential recurrence for:

- scalar and per-step lambda values;
- length-one trajectories;
- non-power-of-two trajectory lengths;
- long trajectories;
- gradients with respect to all differentiable inputs;
- stopped-gradient behavior.

## Tested

- JAX 0.7.0 targeted suite: 67 passed, 16 skipped.
- JAX 0.11.0 targeted suite: 67 passed, 16 skipped.
- Packaged RLax suite: 751 passed, 168 skipped.
- Isolated PopArt suite: 11 passed.
- Package build succeeded.
- Documentation build succeeded.
- Flake8, Ruff, and `git diff --check` passed.
```